### PR TITLE
Add before_deploy build to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ script:
   - npm audit
   - npm test
 
+before_deploy:
+  - npm run build
+  
 deploy:
   provider: npm
   email: $NPM_EMAIL

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-adapter",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Cloudboost MongoDB adapter",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
### What does this PR do?
I noticed that the I was not deploying the `dist` folder because the build command is not ran in the CI. This PR adds a `before_deploy` stage to the CI build that runs `npm build`.