### PR TITLE
Add skip_cleanup to Travis deploy to preserve build artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ script:
 
 before_deploy:
   - npm run build
-  
+
 deploy:
+  skip_cleanup: true
   provider: npm
   email: $NPM_EMAIL
   api_key: $NPM_API_KEY

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-adapter",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Cloudboost MongoDB adapter",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
### What does this PR do?

After the `before_deploy` executes, Travis cleans the git working tree and deletes build artefacts like the `dist` folder. To preserve that I had to add the `skip_cleanup: true` to the deploy step.